### PR TITLE
bump clap to 4.0.15

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      - update-types: ["version-update:semver-major"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,9 @@ keywords = ["command-line-tool", "markdown", "pic-uploader", "cli"]
 anyhow = "1.0.56"
 arboard = "3.1.0"
 base64 = "0.13.0"
-clap = {version = "3.1.8", features = ["cargo"]}
+clap = {version = "4.0.15", features = ["cargo", "derive"]}
 colored = "2.0.0"
+dirs = "4.0.0"
 json = "0.12.4"
 keyring = "1.1.2"
 nix = {version = "0.25.0", default-features = false, features = ["term"]}

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
 # defaults are great:D
+max_width = 80

--- a/src/echo.rs
+++ b/src/echo.rs
@@ -1,10 +1,8 @@
-//! offers functionality of disabling and enabling ECHO on tty
+//! Offers functionality of disabling and enabling ECHO on tty
 
 use nix::sys::termios::{tcgetattr, tcsetattr, LocalFlags, SetArg, Termios};
 
-/// purpose: disable echo on tty configuration
-///
-/// action: unset ECHO bit of termios.c_lflag
+/// Disable echo on tty configuration
 pub fn echo_off() {
     let mut t: Termios = tcgetattr(0).unwrap();
 
@@ -13,9 +11,7 @@ pub fn echo_off() {
     tcsetattr(0, SetArg::TCSANOW, &t).unwrap();
 }
 
-/// purpose: enable echo on tty configuration
-///
-/// action: set ECHO bit of termios.c_lflag
+/// Enable echo on tty configuration
 pub fn echo_on() {
     let mut t: Termios = tcgetattr(0).unwrap();
 

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,4 +1,4 @@
-//! encode file contents
+//! Encode file contents
 
 use base64::{encode_config_slice, STANDARD};
 use std::{
@@ -15,8 +15,9 @@ pub enum EncodeFailedCases {
     CanNotOpenFile,
     CanNotReadFile,
 }
-// impl Debug + Display for our own error type so that
-// we can have std::error::Error implmented
+
+/// impl Debug + Display for our own error type so that we can have
+/// `std::error::Error` implemented
 impl Display for EncodeFailedCases {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self)
@@ -24,13 +25,7 @@ impl Display for EncodeFailedCases {
 }
 impl Error for EncodeFailedCases {}
 
-/// purpose: to encode the image contents
-///
-/// arguments:
-///     * `path`: image path
-///     
-/// return: If successful, return the encoded bytes.
-///         Otherwise return the corressponding error type.
+/// Encode the image contents
 pub fn encode(path: &Path) -> Result<Vec<u8>, EncodeFailedCases> {
     // buffer for the original file contents
     let mut orig_contents: Vec<u8> = Vec::new();
@@ -39,8 +34,11 @@ pub fn encode(path: &Path) -> Result<Vec<u8>, EncodeFailedCases> {
             // buffer for the encoded contents
             let mut encoded_contents: Vec<u8> = Vec::new();
             encoded_contents.resize(orig_contents.len() * 4 / 3 + 4, 0);
-            let n_bytes: usize =
-                encode_config_slice(orig_contents, STANDARD, &mut encoded_contents);
+            let n_bytes: usize = encode_config_slice(
+                orig_contents,
+                STANDARD,
+                &mut encoded_contents,
+            );
             encoded_contents.truncate(n_bytes); // remove the trailing zeros
 
             Ok(encoded_contents)

--- a/src/file_type.rs
+++ b/src/file_type.rs
@@ -10,7 +10,7 @@ pub enum FileType {
     Unknown,
 }
 
-/// construct a [`FileType`] according to the given `path`
+/// Construct a [`FileType`] according to the given `path`
 pub fn file_type<P: AsRef<Path>>(path: P) -> FileType {
     match path.as_ref().extension() {
         Some(os_str_type) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,11 +12,11 @@ mod response;
 mod result;
 mod token;
 
-use crate::manipulation::img_manipulate;
 use crate::{
     cli::{cli_init, get_cli_config},
     config::{check_config, create_config, Cfg},
     file_type::FileType,
+    manipulation::img_manipulate,
     manipulation::md_manipulate,
     result::MdManipulationResult,
 };
@@ -38,8 +38,9 @@ fn main() {
         let mut md_file = canonicalize(cli_cfg.file_path.as_path())
             .expect("Failed to get absolute path of target markdown file");
         md_file.pop();
-        set_current_dir(md_file.as_path())
-            .expect("Failed to set current dir to the parent of the markdown doc");
+        set_current_dir(md_file.as_path()).expect(
+            "Failed to set current dir to the parent of the markdown doc",
+        );
 
         let res: Arc<Mutex<MdManipulationResult>> =
             Arc::new(Mutex::new(MdManipulationResult::default()));

--- a/src/match.rs
+++ b/src/match.rs
@@ -1,4 +1,4 @@
-//! offers `![](/)` match functionality in markdown manipulation
+//! Offers `![](/)` match functionality in markdown manipulation
 
 use regex::{Match, Regex};
 use std::ops::{Index, Range};
@@ -10,10 +10,7 @@ pub struct MatchedLine<'lifetime_of_line> {
 }
 
 impl<'lifetime_of_line> MatchedLine<'lifetime_of_line> {
-    /// purpose: check and initialize a matched line struct
-    ///
-    /// arguments:
-    ///     * `line`: reference to the matched line string
+    /// Check and initialize a matched line struct
     pub fn new(line: &'lifetime_of_line mut String) -> Option<Self> {
         // used to match the markdown image path
         let image_path_re: Regex = Regex::new(r#"!\[.*\]\(.*\)"#).unwrap();
@@ -24,13 +21,18 @@ impl<'lifetime_of_line> MatchedLine<'lifetime_of_line> {
             // used to match the parenthesis
             let parenthesis_re: Regex = Regex::new(r#"\(.*\)"#).unwrap();
             let image_path: &str = line.index(image_path_match.range());
-            let parenthesis_mth: Match = parenthesis_re.find(image_path).unwrap();
+            let parenthesis_mth: Match =
+                parenthesis_re.find(image_path).unwrap();
 
             // calculate the range`[start, end)` of path in this line
-            let start: usize = parenthesis_mth.start() + image_path_match.start() + 1; // inclusive
-            let end: usize = parenthesis_mth.end() + image_path_match.start() - 1; // exclusive
+            let start: usize =
+                parenthesis_mth.start() + image_path_match.start() + 1; // inclusive
+            let end: usize =
+                parenthesis_mth.end() + image_path_match.start() - 1; // exclusive
 
-            if line[start..end].starts_with("https://") || line[start..end].is_empty() {
+            if line[start..end].starts_with("https://")
+                || line[start..end].is_empty()
+            {
                 None
             } else {
                 Some(Self {
@@ -43,10 +45,7 @@ impl<'lifetime_of_line> MatchedLine<'lifetime_of_line> {
         }
     }
 
-    /// purpose: replace the local path with the returned URL
-    ///
-    /// arguments:
-    ///     * `url`: returned URL
+    /// Replace the local path with the returned URL
     pub fn replace(&'lifetime_of_line mut self, url: &str) {
         self.line.replace_range(self.range.clone(), url);
     }
@@ -57,7 +56,8 @@ mod test {
     use super::*;
     #[test]
     fn replace_test() {
-        let mut local_path: String = String::from("> ![title](/home/steve/doc.png)xx");
+        let mut local_path: String =
+            String::from("> ![title](/home/steve/doc.png)xx");
         let mut mth: MatchedLine = MatchedLine::new(&mut local_path).unwrap();
         let target_url = "https://github.com/SteveLauC/pic/blob/main/Screen%20Shot%202022-04-06%20at%2010.30.49%20AM.png";
         mth.replace(target_url);
@@ -66,7 +66,8 @@ mod test {
 
     #[test]
     fn matched_line_init_test() {
-        let mut line: String = String::from("> ![title](/home/steve/doc.png)xx");
+        let mut line: String =
+            String::from("> ![title](/home/steve/doc.png)xx");
         let mth: MatchedLine = MatchedLine::new(&mut line).unwrap();
 
         assert_eq!(mth.range, Range { start: 11, end: 30 });
@@ -84,7 +85,8 @@ mod test {
         let mut line3: String = "![aaa[()".into();
         assert!(MatchedLine::new(&mut line3).is_none());
         // url
-        let mut line4: String = "> 我们不是![ppt](https://.....)xxxx这样".into();
+        let mut line4: String =
+            "> 我们不是![ppt](https://.....)xxxx这样".into();
         assert!(MatchedLine::new(&mut line4).is_none());
         // relative path
         let mut line5: String = "![issustration](pic.png)".into();

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,4 @@
-//! sends HTTP PUT request
+//! Sends HTTP PUT request
 
 use crate::config::Cfg;
 use anyhow::Result;
@@ -7,6 +7,7 @@ use reqwest::{
     header::{HeaderMap, HeaderValue},
 };
 
+/// Initialize a HTTP client and header
 pub fn client_and_header(config: &Cfg) -> (Client, HeaderMap) {
     // init the client
     let http_client = Client::new();
@@ -19,20 +20,14 @@ pub fn client_and_header(config: &Cfg) -> (Client, HeaderMap) {
     );
     headers.append(
         "Authorization",
-        HeaderValue::from_bytes(config.token.as_bytes()).expect("failed to parse header value"),
+        HeaderValue::from_bytes(config.token.as_bytes())
+            .expect("failed to parse header value"),
     );
 
     (http_client, headers)
 }
 
-/// purpose: send PUT request to the GitHub server
-///
-/// arguments:
-///     * `config`: user configuration
-///     * `file_name`: name of the image file
-///     * `file_contents`: base64 encoded file contents
-///
-/// return: None if there is anything wrong with network connection or message initialization
+/// Send PUT request to the GitHub server
 pub fn request(
     client: &Client,
     header: &HeaderMap,

--- a/src/response.rs
+++ b/src/response.rs
@@ -12,7 +12,8 @@ pub enum FailedCases {
     CreatedButUrlNotFound,
     NotCoveredCase,
 }
-// implement Display and Debug for our error type
+
+// Implement Display and Debug for our error type
 // so that we can have std::error::Error implmented
 impl fmt::Display for FailedCases {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -21,19 +22,14 @@ impl fmt::Display for FailedCases {
 }
 impl Error for FailedCases {}
 
-/// purpose: parse URL from the returned json body
-///
-/// arguments:
-///     * `body`: HTTP response
-///     
-/// return: If successful, return `html_url` parsed from the response body.
-///         Otherwise return the corressponding error type
+/// Parse URL from the returned json body
 pub fn get_url(body: Response) -> Result<String, FailedCases> {
     match body.status() {
         // returns 201
         StatusCode::CREATED => {
             let body: String = body.text().expect("can not get response body");
-            let val: Value = from_str(&body).expect("can not parse response body");
+            let val: Value =
+                from_str(&body).expect("can not parse response body");
             if let Value::String(ref url) = val["content"]["html_url"] {
                 Ok(url.clone())
             } else {

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,4 +1,4 @@
-//! manipulation result
+//! Manipulation result handling
 
 use colored::Colorize;
 use std::{
@@ -16,12 +16,12 @@ pub struct MdManipulationResult {
 }
 
 impl MdManipulationResult {
-    /// purpose: handle the result of function `manipulate_mthed_line`
-    ///
-    /// arguments:
-    ///     * `res`: return value of `manipulate_mthed_line`
-    ///     * `image`: image path
-    pub fn res_handling(&mut self, res: Result<(), Box<dyn Error>>, image_path: &Path) {
+    /// Check out the result of our image manipulation and report it to the user.
+    pub fn res_handling(
+        &mut self,
+        res: Result<(), Box<dyn Error>>,
+        image_path: &Path,
+    ) {
         self.total += 1;
         if let Err(msg) = res {
             println!("find: {:?}\n[{}]: {:?}", image_path, "FAILED".red(), msg);
@@ -33,6 +33,8 @@ impl MdManipulationResult {
     }
 }
 
+/// Make [MdManipulationResult] printable so that we can display the statistics
+/// when task finishes.
 impl Display for MdManipulationResult {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln!(

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,4 +1,4 @@
-//! offers functionality of fetching, updating and deleting your secret TOKEN
+//! Offers functionality of fetching, updating and deleting your secret TOKEN
 
 use crate::echo::{echo_off, echo_on};
 use keyring::{Entry, Result};
@@ -7,10 +7,8 @@ use std::{
     process::exit,
 };
 
-/// purpose: fetch token from system passwrod mangaement
-///          if it is not set yet, ask the user to input and then store it
-///          
-/// return: the TOKEN
+/// fetch token from system passwrod mangaement if it is not set yet, ask the
+/// user to input and then store it
 pub fn fetch_token() -> String {
     let pup: Entry = Entry::new("pup", "pup");
 
@@ -22,12 +20,9 @@ pub fn fetch_token() -> String {
     }
 }
 
-/// purpose: update token
+/// Update the TOKEN.
 ///
-/// action: Old TOKEN will be overridden if there was a old token; If there was
-///         no token, set a new one.
-///       
-/// return: `Ok(())` on success, `keyring::error::Error` on error.
+/// Old TOKEN will be overridden if it exists, or a new one will be set.
 pub fn update_token() -> Result<()> {
     let pup: Entry = Entry::new("pup", "pup");
     print!("Please input the new TOKEN: ");
@@ -41,13 +36,7 @@ pub fn update_token() -> Result<()> {
     pup.set_password(new_token.as_str())
 }
 
-/// purpose: delete the existing TOKEN
-///
-/// action: delete the TOKEN if there was one
-///
-/// return: when there is a TOKEN, `Ok(())` on success, `keyring::error::Error`
-///         on error.
-///         Exit the whole program if no TOKEN available
+/// Delete the existing TOKEN, if there is no TOKEN set, return.
 pub fn delete_token() -> Result<()> {
     let pup: Entry = Entry::new("pup", "pup");
     if pup.get_password().is_ok() {


### PR DESCRIPTION
#### What this PR does
1. Bump clap from `3.0.18` to `4.0.15`
2. Use [`dirs`](https://crates.io/crates/dirs) to handle the configuration file path.
3. Document clean up
4. Make `dependabot` ignore major version updates.
5. Remove some unnecessary unit tests.