### PR TITLE
refactor(config): use serde to parse the config file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ keyring = "1.2.0"
 rayon = "1.6.1"
 regex = "1.7.0"
 reqwest = { version = "0.11.13", features = ["blocking"] }
-serde = "1.0.150"
+serde = {version = "1.0.150", features = ["derive"]}
 serde_json = "1.0.79"
 toml = "0.5.9"
 termios = "0.3.3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,32 +12,60 @@
 //! | macOS   | `$HOME`/Library/Application Support/pup/config.toml                   |
 
 use crate::token::fetch_token;
-use colored::Colorize;
 use dirs::config_dir;
+use serde::Deserialize;
+use std::fs::read_to_string;
 use std::{
-    fs::{create_dir, File, OpenOptions},
-    io::{Read, Write},
+    fs::{create_dir, OpenOptions},
+    io::Write,
     os::unix::fs::OpenOptionsExt,
     path::PathBuf,
     process::exit,
 };
-use toml::Value;
 
 /// User configuration file template
-const TEMPLETE: &str = r#"# configuration file for pup
-[user]
-github-user-name = ""
-github-repo-name = ""
-mail = ""
+const TEMPLETE: &str = r#"# Configuration file for pup
+github_user_name = "your_user_name"
+github_repo_name = "your_repo_name"
+mail = "your_mail_address"
 "#;
 
 /// type to represent the user configuration
-#[derive(Debug)]
+#[derive(Debug, Deserialize)]
 pub struct UserConfig {
-    pub name: String,
-    pub repo: String,
+    pub github_user_name: String,
+    pub github_repo_name: String,
     pub mail: String,
-    pub token: String,
+    // This field is `Option`al since it will NOT be present in the
+    // configuration file, to make `serde` successfully parse it without any
+    // error, will make it `Option`al here.
+    //
+    // But an initialized `UserConfig` will NEVER have this field set to `None`,
+    // feel free to call `.unwrap()` on it.
+    pub token: Option<String>,
+}
+
+impl UserConfig {
+    /// Try to construct an `UserConfig`.
+   pub fn load() -> Self {
+       let config_path = config_file_path();
+       let config_file_contents = read_to_string(config_path.as_path())
+           .expect("pup: can not read config file");
+
+       match toml::from_str::<UserConfig>(&config_file_contents) {
+           Ok(mut config) => {
+               config.token = Some(fetch_token());
+               config
+           }
+           Err(msg) => {
+               eprintln!(
+                   "pup: can not parse the configuration file due to: `{}`",
+                   msg
+               );
+               exit(1);
+           }
+       }
+   }
 }
 
 /// Return config directory path
@@ -106,73 +134,6 @@ pub fn init_config() {
                 );
                 exit(1);
             }
-        }
-    }
-}
-
-/// Try to construct an `UserConfig`.
-///
-/// This function will check every fields of the config file to see if any of
-/// them is empty. If so, warn user and exit the program.
-pub fn get_user_config() -> UserConfig {
-    let config_path = config_file_path();
-
-    match File::open(config_path.as_path()) {
-        Ok(mut file) => {
-            // buf to store the config file contents
-            let mut buf: String = String::with_capacity(200);
-            file.read_to_string(&mut buf)
-                .expect("pup: can not read config file contents");
-
-            // parse the configuration file
-            match buf.parse::<Value>() {
-                Ok(config) => {
-                    let name =
-                        config["user"]["github-user-name"].as_str().expect(
-                            "config.toml: missing user/github-user-name field",
-                        );
-                    let repo =
-                        config["user"]["github-repo-name"].as_str().expect(
-                            "config.toml: missing user/github-repo-name field",
-                        );
-                    let mail = config["user"]["mail"]
-                        .as_str()
-                        .expect("config.toml: missing user/mail field");
-
-                    // sign used to record whether there are empty fields
-                    let mut field_empty_sign = false;
-
-                    if name.is_empty() {
-                        eprintln!("{} is unset.", "name".red());
-                        field_empty_sign = true;
-                    }
-                    if repo.is_empty() {
-                        eprintln!("{} is unset.", "repo".red());
-                        field_empty_sign = true;
-                    }
-                    if mail.is_empty() {
-                        eprintln!("{} is unset.", "mail".red());
-                        field_empty_sign = true;
-                    }
-                    if field_empty_sign {
-                        exit(1);
-                    }
-                    UserConfig {
-                        name: name.into(),
-                        repo: repo.into(),
-                        mail: mail.into(),
-                        token: fetch_token(),
-                    }
-                }
-                Err(msg) => {
-                    eprintln!("pup: invalid config file due to {}", msg);
-                    exit(1);
-                }
-            }
-        }
-        Err(msg) => {
-            eprintln!("pup: can not read {:?} due to {}", config_path, msg);
-            exit(1);
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,25 +47,25 @@ pub struct UserConfig {
 
 impl UserConfig {
     /// Try to construct an `UserConfig`.
-   pub fn load() -> Self {
-       let config_path = config_file_path();
-       let config_file_contents = read_to_string(config_path.as_path())
-           .expect("pup: can not read config file");
+    pub fn load() -> Self {
+        let config_path = config_file_path();
+        let config_file_contents = read_to_string(config_path.as_path())
+            .expect("pup: can not read config file");
 
-       match toml::from_str::<UserConfig>(&config_file_contents) {
-           Ok(mut config) => {
-               config.token = Some(fetch_token());
-               config
-           }
-           Err(msg) => {
-               eprintln!(
-                   "pup: can not parse the configuration file due to: `{}`",
-                   msg
-               );
-               exit(1);
-           }
-       }
-   }
+        match toml::from_str::<UserConfig>(&config_file_contents) {
+            Ok(mut config) => {
+                config.token = Some(fetch_token());
+                config
+            }
+            Err(msg) => {
+                eprintln!(
+                    "pup: can not parse the configuration file due to: `{}`",
+                    msg
+                );
+                exit(1);
+            }
+        }
+    }
 }
 
 /// Return config directory path

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ mod token;
 
 use crate::{
     cli::{cli_init, get_target_file},
-    config::{UserConfig, init_config},
+    config::{init_config, UserConfig},
     file_type::FileType,
     manipulation::img_manipulate,
     manipulation::md_manipulate,

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ mod token;
 
 use crate::{
     cli::{cli_init, get_target_file},
-    config::{get_user_config, init_config},
+    config::{UserConfig, init_config},
     file_type::FileType,
     manipulation::img_manipulate,
     manipulation::md_manipulate,
@@ -51,7 +51,7 @@ fn adjust_pwd(target_markdown_file_path: &Path) {
 
 fn main() {
     init_config();
-    let user_config = get_user_config();
+    let user_config = UserConfig::load();
 
     // if filename option is given
     if let Some(target_file) = get_target_file(&cli_init()) {

--- a/src/manipulation.rs
+++ b/src/manipulation.rs
@@ -36,7 +36,7 @@ pub fn md_manipulate(
         .lines()
         .map(|item| item.unwrap())
         .collect::<Vec<String>>();
-    let uploader = Uploader::init(config.token.as_str());
+    let uploader = Uploader::init(config.token.as_ref().unwrap());
 
     lines.par_iter_mut().for_each(|line| {
         line.push('\n');
@@ -99,7 +99,7 @@ fn clipboard_set(contents: &str) {
 
 /// Manipulate single image file
 pub fn img_manipulate(target_file: &TargetFile, config: &UserConfig) {
-    let uploader = Uploader::init(config.token.as_str());
+    let uploader = Uploader::init(config.token.as_ref().unwrap());
     let response = uploader
         .upload(target_file.file_path.as_path(), config)
         .expect("Failed to upload");

--- a/src/request.rs
+++ b/src/request.rs
@@ -61,7 +61,7 @@ impl Uploader {
         */
         let mut json_body= format!(
             "{{\"message\": \"upload\", \"commiter\": {{\"name\": \"{}\", \"email\":\"{}\"}}, \"content\": \"",
-            user_cfg.name,
+            user_cfg.github_user_name,
             user_cfg.mail
         ).into_bytes();
         json_body.extend_from_slice(&encoded_file_contents);
@@ -70,7 +70,7 @@ impl Uploader {
         // target URL
         let url = format!(
             "https://api.github.com/repos/{}/{}/contents/{}",
-            user_cfg.name, user_cfg.repo, file_name
+            user_cfg.github_user_name, user_cfg.github_repo_name, file_name
         );
 
         let res = self


### PR DESCRIPTION
#### What this PR does:

In the previous implementation, we manually parse our config file, which introduces too much boilerplate code, this PR uses `serde` to parse the toml file.

#### Drawback
We checked empty config values before,  we no longer do this since this PR:
```rust
if name.is_empty() {
    eprintln!("{} is unset.", "name".red());
    field_empty_sign = true;
}
```

Users have to make sure their config is correct...
