### PR TITLE
fix: can not set token

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,1 @@
-# defaults are great:D
-max_width = 80
+max_width = 100

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,10 +11,7 @@ use crate::{
     file_type::{file_type, FileType},
     token::{delete_token, update_token},
 };
-use clap::{
-    crate_authors, crate_description, crate_version, Arg, ArgAction,
-    ArgMatches, Command,
-};
+use clap::{crate_authors, crate_description, crate_version, Arg, ArgAction, ArgMatches, Command};
 use std::{
     path::{Path, PathBuf},
     process::exit,
@@ -109,6 +106,10 @@ pub fn token_opt(app: &ArgMatches) {
 ///   return None
 ///
 /// NOTE: we need to make sure `filepath` exists
+//
+// TODO: `get_target_file` is a bad API , it handles all the
+// CLI arguments instead of just extracting the target file, and thus should
+// be refactored.
 pub fn get_target_file(app: &ArgMatches) -> Option<TargetFile> {
     // Handle two token-related opt
     token_opt(app);

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,9 +14,8 @@
 use crate::token::fetch_token;
 use dirs::config_dir;
 use serde::Deserialize;
-use std::fs::read_to_string;
 use std::{
-    fs::{create_dir, OpenOptions},
+    fs::{create_dir, read_to_string, OpenOptions},
     io::Write,
     os::unix::fs::OpenOptionsExt,
     path::PathBuf,
@@ -49,8 +48,8 @@ impl UserConfig {
     /// Try to construct an `UserConfig`.
     pub fn load() -> Self {
         let config_path = config_file_path();
-        let config_file_contents = read_to_string(config_path.as_path())
-            .expect("pup: can not read config file");
+        let config_file_contents =
+            read_to_string(config_path.as_path()).expect("pup: can not read config file");
 
         match toml::from_str::<UserConfig>(&config_file_contents) {
             Ok(mut config) => {
@@ -103,10 +102,7 @@ pub fn init_config() {
 
     if !config_dir_path.exists() {
         if let Err(msg) = create_dir(config_dir_path.as_path()) {
-            eprintln!(
-                "pup: can not create {:?} due to {}",
-                config_dir_path, msg
-            );
+            eprintln!("pup: can not create {:?} due to {}", config_dir_path, msg);
             exit(1);
         }
     }
@@ -128,10 +124,7 @@ pub fn init_config() {
                 }
             }
             Err(msg) => {
-                eprintln!(
-                    "pup: can not create {:?} due to {}",
-                    config_file_path, msg
-                );
+                eprintln!("pup: can not create {:?} due to {}", config_file_path, msg);
                 exit(1);
             }
         }

--- a/src/echo.rs
+++ b/src/echo.rs
@@ -6,24 +6,20 @@ use termios::{tcsetattr, Termios, ECHO, TCSANOW};
 ///
 /// action: unset ECHO bit of termios.c_lflag
 pub fn echo_off() {
-    let mut t = Termios::from_fd(0)
-        .expect("pup(tcgetattr): failed to get terminal configuration");
+    let mut t = Termios::from_fd(0).expect("pup(tcgetattr): failed to get terminal configuration");
 
     t.c_lflag &= !ECHO;
 
-    tcsetattr(0, TCSANOW, &t)
-        .expect("pup(tcsetattr): failed to turn off echo bit");
+    tcsetattr(0, TCSANOW, &t).expect("pup(tcsetattr): failed to turn off echo bit");
 }
 
 /// purpose: enable echo on tty configuration
 ///
 /// action: set ECHO bit of termios.c_lflag
 pub fn echo_on() {
-    let mut t = Termios::from_fd(0)
-        .expect("pup(tcgetattr): failed to get terminal configuration");
+    let mut t = Termios::from_fd(0).expect("pup(tcgetattr): failed to get terminal configuration");
 
     t.c_lflag |= ECHO;
 
-    tcsetattr(0, TCSANOW, &t)
-        .expect("pup(tcsetattr): failed to turn on echo bit")
+    tcsetattr(0, TCSANOW, &t).expect("pup(tcsetattr): failed to turn on echo bit")
 }

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -10,11 +10,7 @@ pub fn encode(path: &Path) -> Result<Vec<u8>> {
     // buffer for the encoded contents
     let mut encoded_contents = Vec::new();
     encoded_contents.resize(orig_contents.len() * 4 / 3 + 4, 0);
-    let n_bytes = encode_engine_slice(
-        orig_contents,
-        &mut encoded_contents,
-        &DEFAULT_ENGINE,
-    );
+    let n_bytes = encode_engine_slice(orig_contents, &mut encoded_contents, &DEFAULT_ENGINE);
     // remove the trailing zeros
     encoded_contents.truncate(n_bytes);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,7 @@ use crate::{
     cli::{cli_init, get_target_file},
     config::{init_config, UserConfig},
     file_type::FileType,
-    manipulation::img_manipulate,
-    manipulation::md_manipulate,
+    manipulation::{img_manipulate, md_manipulate},
     result::MdManipulationResult,
 };
 use std::{
@@ -51,18 +50,19 @@ fn adjust_pwd(target_markdown_file_path: &Path) {
 
 fn main() {
     init_config();
+    let app = cli_init();
+    let target_file_opt = get_target_file(&app);
     let user_config = UserConfig::load();
 
     // if filename option is given
-    if let Some(target_file) = get_target_file(&cli_init()) {
+    if let Some(target_file) = target_file_opt {
         match target_file.file_type {
             FileType::Unknown => {
                 eprintln!("Unknown file type, abort.");
                 exit(1);
             }
             FileType::Markdown => {
-                let result =
-                    Arc::new(Mutex::new(MdManipulationResult::default()));
+                let result = Arc::new(Mutex::new(MdManipulationResult::default()));
                 adjust_pwd(target_file.file_path.as_path());
                 md_manipulate(&target_file, &user_config, result);
             }

--- a/src/manipulation.rs
+++ b/src/manipulation.rs
@@ -7,8 +7,8 @@
 //! system clipboard.
 
 use crate::{
-    cli::TargetFile, config::UserConfig, r#match::MatchedLine,
-    request::Uploader, response::get_url, result::MdManipulationResult,
+    cli::TargetFile, config::UserConfig, r#match::MatchedLine, request::Uploader,
+    response::get_url, result::MdManipulationResult,
 };
 use arboard::Clipboard;
 use colored::Colorize;
@@ -29,8 +29,7 @@ pub fn md_manipulate(
 ) {
     // buffer-wrapped target file
     let md_file = BufReader::new(
-        File::open(target_file.file_path.as_path())
-            .expect("can not open target file"),
+        File::open(target_file.file_path.as_path()).expect("can not open target file"),
     );
     let mut lines = md_file
         .lines()
@@ -43,8 +42,7 @@ pub fn md_manipulate(
 
         if let Some(mut mth) = MatchedLine::new(line) {
             // to escape simultaneous occurrence of mutable and immutable borrowing
-            let image_path =
-                Path::new(mth.line.index(mth.range.clone())).to_path_buf();
+            let image_path = Path::new(mth.line.index(mth.range.clone())).to_path_buf();
             res.lock().unwrap().res_handling(
                 manipulate_mthed_line(&uploader, &mut mth, config),
                 image_path.as_path(),
@@ -90,8 +88,7 @@ fn manipulate_mthed_line<'a>(
 /// A helper function used in [`img_manipulate`].
 #[inline]
 fn clipboard_set(contents: &str) {
-    let mut clipboard =
-        Clipboard::new().expect("failed to initialize a clipboard instance");
+    let mut clipboard = Clipboard::new().expect("failed to initialize a clipboard instance");
     clipboard
         .set_text(contents)
         .expect("can not store the returned URL to clipboard");
@@ -104,8 +101,7 @@ pub fn img_manipulate(target_file: &TargetFile, config: &UserConfig) {
         .upload(target_file.file_path.as_path(), config)
         .expect("Failed to upload");
 
-    let url = get_url(response)
-        .expect("failed to extract URL from the response message");
+    let url = get_url(response).expect("failed to extract URL from the response message");
     clipboard_set(url.as_str());
 
     println!("{} [{}]", target_file.file_path.display(), "done".green());

--- a/src/match.rs
+++ b/src/match.rs
@@ -35,9 +35,7 @@ impl<'lifetime_of_line> MatchedLine<'lifetime_of_line> {
             let start = parenthesis_mth.start() + image_path_match.start() + 1; // inclusive
             let end = parenthesis_mth.end() + image_path_match.start() - 1; // exclusive
 
-            if line[start..end].starts_with("https://")
-                || line[start..end].is_empty()
-            {
+            if line[start..end].starts_with("https://") || line[start..end].is_empty() {
                 None
             } else {
                 Some(Self {
@@ -61,8 +59,7 @@ mod test {
     use super::*;
     #[test]
     fn replace_test() {
-        let mut local_path: String =
-            String::from("> ![title](/home/steve/doc.png)xx");
+        let mut local_path: String = String::from("> ![title](/home/steve/doc.png)xx");
         let mut mth: MatchedLine = MatchedLine::new(&mut local_path).unwrap();
         let target_url = "https://github.com/SteveLauC/pic/blob/main/Screen%20Shot%202022-04-06%20at%2010.30.49%20AM.png";
         mth.replace(target_url);
@@ -71,8 +68,7 @@ mod test {
 
     #[test]
     fn matched_line_init_test() {
-        let mut line: String =
-            String::from("> ![title](/home/steve/doc.png)xx");
+        let mut line: String = String::from("> ![title](/home/steve/doc.png)xx");
         let mth: MatchedLine = MatchedLine::new(&mut line).unwrap();
 
         assert_eq!(mth.range, Range { start: 11, end: 30 });
@@ -90,8 +86,7 @@ mod test {
         let mut line3: String = "![aaa[()".into();
         assert!(MatchedLine::new(&mut line3).is_none());
         // url
-        let mut line4: String =
-            "> 我们不是![ppt](https://.....)xxxx这样".into();
+        let mut line4: String = "> 我们不是![ppt](https://.....)xxxx这样".into();
         assert!(MatchedLine::new(&mut line4).is_none());
         // relative path
         let mut line5: String = "![issustration](pic.png)".into();

--- a/src/request.rs
+++ b/src/request.rs
@@ -40,11 +40,7 @@ impl Uploader {
     }
 
     /// Upload file specified in `path` to the Repo.
-    pub fn upload<P: AsRef<Path>>(
-        &self,
-        path: P,
-        user_cfg: &UserConfig,
-    ) -> Result<Response> {
+    pub fn upload<P: AsRef<Path>>(&self, path: P, user_cfg: &UserConfig) -> Result<Response> {
         let encoded_file_contents = encode(path.as_ref())?;
         let file_name = path.as_ref().file_name().unwrap().to_str().unwrap();
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -23,8 +23,7 @@ pub fn get_url(body: Response) -> Result<String, FailedCases> {
         // returns 201
         StatusCode::CREATED => {
             let body: String = body.text().expect("can not get response body");
-            let val: Value =
-                from_str(&body).expect("can not parse response body");
+            let val: Value = from_str(&body).expect("can not parse response body");
             if let Value::String(ref url) = val["content"]["html_url"] {
                 Ok(url.clone())
             } else {

--- a/src/result.rs
+++ b/src/result.rs
@@ -16,11 +16,7 @@ pub struct MdManipulationResult {
 
 impl MdManipulationResult {
     /// Check out the result of our image manipulation and report it to the user.
-    pub fn res_handling(
-        &mut self,
-        res: Result<(), Box<dyn Error>>,
-        image_path: &Path,
-    ) {
+    pub fn res_handling(&mut self, res: Result<(), Box<dyn Error>>, image_path: &Path) {
         self.total += 1;
         if let Err(msg) = res {
             println!("find: {:?}\n[{}]: {:?}", image_path, "FAILED".red(), msg);


### PR DESCRIPTION
# What this PR does:
Fix the bug that `--update-token` can not be invoked as TOKEN needs to be set before processing any cli arguments.