### PR TITLE
feat: print response body when we cannot extract the returned URL

### DIFF
--- a/src/operation/manipulation.rs
+++ b/src/operation/manipulation.rs
@@ -73,7 +73,6 @@ pub fn md_manipulate(
 /// Deal with every matched line.
 ///
 /// This is the helper function used inside of [`md_manipulate`].
-#[inline]
 fn manipulate_mthed_line<'a>(
     uploader: &Uploader,
     mth: &'a mut MatchedLine<'a>,
@@ -89,7 +88,6 @@ fn manipulate_mthed_line<'a>(
 /// Places `contents` into the clipboard.
 ///
 /// A helper function used in [`img_manipulate`].
-#[inline]
 fn clipboard_set(contents: &str) {
     let mut clipboard = Clipboard::new().expect("failed to initialize a clipboard instance");
     clipboard

--- a/src/util/response.rs
+++ b/src/util/response.rs
@@ -35,6 +35,9 @@ pub fn get_url(body: Response) -> Result<String, FailedCases> {
         // returns 422
         StatusCode::UNPROCESSABLE_ENTITY => Err(FailedCases::ValidationFailed),
         // other cases of failure which are not covered right now
-        _ => Err(FailedCases::NotCoveredCase),
+        _ => {
+            eprintln!("Response: {:#?}", body);
+            Err(FailedCases::NotCoveredCase)
+        }
     }
 }


### PR DESCRIPTION
Print the response body when the error case is not covered by us.

And, remove 2 `inline` attributes for private functions as it will work public interfaces.